### PR TITLE
Fix pruning issue & dfract params serialization

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -664,7 +664,7 @@ func (app *App) registerUpgradeHandlers() {
 
 	app.UpgradeKeeper.SetUpgradeHandler("v1.3.2", func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 		// Set the IBCFee module consensus version so InitGenesis is not run
-		fromVM[ibcfeetypes.ModuleName] = app.mm.Modules[ibcfeetypes.ModuleName].ConsensusVersion()
+		fromVM[ibcfeetypes.ModuleName] = 0
 		app.Logger().Info("v1.3.2 upgrade applied")
 		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
 	})

--- a/app/app.go
+++ b/app/app.go
@@ -280,7 +280,6 @@ func New(
 		upgrade.NewAppModule(*app.UpgradeKeeper),
 		evidence.NewAppModule(*app.EvidenceKeeper),
 		ibc.NewAppModule(app.IBCKeeper),
-		ibcfee.NewAppModule(app.IBCFeeKeeper),
 		ica.NewAppModule(nil, app.ICAHostKeeper),
 		params.NewAppModule(*app.ParamsKeeper),
 		app.transferModule,
@@ -314,7 +313,6 @@ func New(
 		paramstypes.ModuleName,
 		vestingtypes.ModuleName,
 		ibctransfertypes.ModuleName,
-		ibcfeetypes.ModuleName,
 		beamtypes.ModuleName,
 		airdroptypes.ModuleName,
 		dfracttypes.ModuleName,
@@ -340,7 +338,6 @@ func New(
 		ibchost.ModuleName,
 		icatypes.ModuleName,
 		ibctransfertypes.ModuleName,
-		ibcfeetypes.ModuleName,
 		beamtypes.ModuleName,
 		airdroptypes.ModuleName,
 		dfracttypes.ModuleName,
@@ -367,7 +364,6 @@ func New(
 		genutiltypes.ModuleName,
 		evidencetypes.ModuleName,
 		ibctransfertypes.ModuleName,
-		ibcfeetypes.ModuleName,
 		feegrant.ModuleName,
 		paramstypes.ModuleName,
 		vestingtypes.ModuleName,
@@ -716,6 +712,8 @@ func (app *App) registerUpgradeHandlers() {
 	if upgradeInfo.Name == "v1.3.2" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		// NOT FINALIZED UPGRADE - FOR LATER
 		// TODO: add the storekey to store init line 229
+		// TODO: add the IBCFee NewAppModule declaration
+		// TODO: add the IBCFee declaration in BeginBlockers, EndBlockers and InitGenesis
 		storeUpgrades := storetypes.StoreUpgrades{
 			Added: []string{ibcfeetypes.ModuleName},
 		}

--- a/app/app.go
+++ b/app/app.go
@@ -707,4 +707,12 @@ func (app *App) registerUpgradeHandlers() {
 		}
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}
+
+	if upgradeInfo.Name == "v1.3.2" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		// NOT FINALIZED UPGRADE - FOR LATER
+		storeUpgrades := storetypes.StoreUpgrades{
+			Added: []string{ibcfeetypes.ModuleName},
+		}
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+	}
 }

--- a/app/app.go
+++ b/app/app.go
@@ -656,6 +656,9 @@ func (app *App) registerUpgradeHandlers() {
 	})
 
 	app.UpgradeKeeper.SetUpgradeHandler("v1.3.1", func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		// Set the IBCFee module consensus version so InitGenesis is not run
+		fromVM[ibcfeetypes.ModuleName] = app.mm.Modules[ibcfeetypes.ModuleName].ConsensusVersion()
+
 		// Apply the new dfract params map
 		app.DFractKeeper.SetParams(ctx, dfracttypes.DefaultParams())
 		app.Logger().Info("v1.3.1 upgrade applied")

--- a/app/app.go
+++ b/app/app.go
@@ -658,14 +658,6 @@ func (app *App) registerUpgradeHandlers() {
 		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
 	})
 
-	app.UpgradeKeeper.SetUpgradeHandler("v1.3.2", func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		// Set the IBCFee module consensus version so InitGenesis is not run
-		fromVM[ibcfeetypes.ModuleName] = app.mm.Modules[ibcfeetypes.ModuleName].ConsensusVersion()
-
-		app.Logger().Info("v1.3.2 upgrade applied")
-		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
-	})
-
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
 	if err != nil {
 		panic(fmt.Sprintf("failed to read upgrade info from disk %s", err))
@@ -705,17 +697,6 @@ func (app *App) registerUpgradeHandlers() {
 	if upgradeInfo.Name == "v1.3.1" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{
 			Deleted: []string{ibcfeetypes.ModuleName},
-		}
-		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
-	}
-
-	if upgradeInfo.Name == "v1.3.2" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
-		// NOT FINALIZED UPGRADE - FOR LATER
-		// TODO: add the storekey to store init line 229
-		// TODO: add the IBCFee NewAppModule declaration
-		// TODO: add the IBCFee declaration in BeginBlockers, EndBlockers and InitGenesis
-		storeUpgrades := storetypes.StoreUpgrades{
-			Added: []string{ibcfeetypes.ModuleName},
 		}
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -663,10 +663,6 @@ func (app *App) registerUpgradeHandlers() {
 	})
 
 	app.UpgradeKeeper.SetUpgradeHandler("v1.3.2", func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		storeUpgrades := storetypes.StoreUpgrades{
-			Added: []string{ibcfeetypes.ModuleName},
-		}
-		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(plan.Height, &storeUpgrades))
 		app.Logger().Info("v1.3.2 upgrade applied")
 		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
 	})
@@ -716,5 +712,11 @@ func (app *App) registerUpgradeHandlers() {
 
 	if upgradeInfo.Name == "v1.3.2" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		// NOT FINALIZED UPGRADE - FOR LATER
+		storeUpgrades := storetypes.StoreUpgrades{
+			Added: []string{ibcfeetypes.ModuleName},
+		}
+		app.SetStoreLoader(func(ms sdk.CommitMultiStore) error {
+			return ms.LoadVersionAndUpgrade(1, &storeUpgrades)
+		})
 	}
 }

--- a/app/app.go
+++ b/app/app.go
@@ -655,6 +655,13 @@ func (app *App) registerUpgradeHandlers() {
 		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
 	})
 
+	app.UpgradeKeeper.SetUpgradeHandler("v1.3.1", func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		// Apply the new dfract params map
+		app.DFractKeeper.SetParams(ctx, dfracttypes.DefaultParams())
+		app.Logger().Info("v1.3.1 upgrade applied")
+		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
+	})
+
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
 	if err != nil {
 		panic(fmt.Sprintf("failed to read upgrade info from disk %s", err))
@@ -688,6 +695,13 @@ func (app *App) registerUpgradeHandlers() {
 
 	if upgradeInfo.Name == "v1.3.0" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{}
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+	}
+
+	if upgradeInfo.Name == "v1.3.1" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		storeUpgrades := storetypes.StoreUpgrades{
+			Added: []string{ibcfeetypes.ModuleName},
+		}
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}
 }

--- a/app/app.go
+++ b/app/app.go
@@ -704,7 +704,6 @@ func (app *App) registerUpgradeHandlers() {
 	if upgradeInfo.Name == "v1.3.1" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{
 			Deleted: []string{ibcfeetypes.ModuleName},
-			Added:   []string{ibcfeetypes.ModuleName},
 		}
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -716,7 +716,7 @@ func (app *App) registerUpgradeHandlers() {
 			Added: []string{ibcfeetypes.ModuleName},
 		}
 		app.SetStoreLoader(func(ms sdk.CommitMultiStore) error {
-			return ms.LoadVersionAndUpgrade(1, &storeUpgrades)
+			return ms.LoadVersionAndUpgrade(0, &storeUpgrades)
 		})
 	}
 }

--- a/app/app.go
+++ b/app/app.go
@@ -656,6 +656,9 @@ func (app *App) registerUpgradeHandlers() {
 	})
 
 	app.UpgradeKeeper.SetUpgradeHandler("v1.3.1", func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		// Set the FeeIBC module consensus version so InitGenesis is not run
+		fromVM[ibcfeetypes.ModuleName] = app.mm.Modules[dfracttypes.ModuleName].ConsensusVersion()
+		
 		// Apply the new dfract params map
 		app.DFractKeeper.SetParams(ctx, dfracttypes.DefaultParams())
 		app.Logger().Info("v1.3.1 upgrade applied")

--- a/app/app.go
+++ b/app/app.go
@@ -656,9 +656,6 @@ func (app *App) registerUpgradeHandlers() {
 	})
 
 	app.UpgradeKeeper.SetUpgradeHandler("v1.3.1", func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		// Set the FeeIBC module consensus version so InitGenesis is not run
-		fromVM[ibcfeetypes.ModuleName] = 1
-
 		// Apply the new dfract params map
 		app.DFractKeeper.SetParams(ctx, dfracttypes.DefaultParams())
 		app.Logger().Info("v1.3.1 upgrade applied")
@@ -703,6 +700,11 @@ func (app *App) registerUpgradeHandlers() {
 
 	if upgradeInfo.Name == "v1.3.1" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{
+			Deleted: []string{ibcfeetypes.ModuleName},
+		}
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+
+		storeUpgrades = storetypes.StoreUpgrades{
 			Added: []string{ibcfeetypes.ModuleName},
 		}
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))

--- a/app/app.go
+++ b/app/app.go
@@ -663,8 +663,10 @@ func (app *App) registerUpgradeHandlers() {
 	})
 
 	app.UpgradeKeeper.SetUpgradeHandler("v1.3.2", func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		// Set the IBCFee module consensus version so InitGenesis is not run
-		fromVM[ibcfeetypes.ModuleName] = 0
+		storeUpgrades := storetypes.StoreUpgrades{
+			Added: []string{ibcfeetypes.ModuleName},
+		}
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(plan.Height, &storeUpgrades))
 		app.Logger().Info("v1.3.2 upgrade applied")
 		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
 	})
@@ -714,9 +716,5 @@ func (app *App) registerUpgradeHandlers() {
 
 	if upgradeInfo.Name == "v1.3.2" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		// NOT FINALIZED UPGRADE - FOR LATER
-		storeUpgrades := storetypes.StoreUpgrades{
-			Added: []string{ibcfeetypes.ModuleName},
-		}
-		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}
 }

--- a/app/app.go
+++ b/app/app.go
@@ -716,7 +716,10 @@ func (app *App) registerUpgradeHandlers() {
 			Added: []string{ibcfeetypes.ModuleName},
 		}
 		app.SetStoreLoader(func(ms sdk.CommitMultiStore) error {
-			return ms.LoadVersionAndUpgrade(0, &storeUpgrades)
+			if err := ms.SetInitialVersion(upgradeInfo.Height); err != nil {
+				panic(err)
+			}
+			return ms.LoadLatestVersionAndUpgrade(&storeUpgrades)
 		})
 	}
 }

--- a/app/app.go
+++ b/app/app.go
@@ -663,6 +663,9 @@ func (app *App) registerUpgradeHandlers() {
 	})
 
 	app.UpgradeKeeper.SetUpgradeHandler("v1.3.2", func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		// Set the IBCFee module consensus version so InitGenesis is not run
+		fromVM[ibcfeetypes.ModuleName] = app.mm.Modules[ibcfeetypes.ModuleName].ConsensusVersion()
+
 		app.Logger().Info("v1.3.2 upgrade applied")
 		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
 	})

--- a/app/app.go
+++ b/app/app.go
@@ -656,9 +656,6 @@ func (app *App) registerUpgradeHandlers() {
 	})
 
 	app.UpgradeKeeper.SetUpgradeHandler("v1.3.1", func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		// Set the DFract module consensus version so InitGenesis is not run
-		fromVM[ibcfeetypes.ModuleName] = app.mm.Modules[ibcfeetypes.ModuleName].ConsensusVersion()
-
 		// Apply the new dfract params map
 		app.DFractKeeper.SetParams(ctx, dfracttypes.DefaultParams())
 		app.Logger().Info("v1.3.1 upgrade applied")
@@ -703,7 +700,8 @@ func (app *App) registerUpgradeHandlers() {
 
 	if upgradeInfo.Name == "v1.3.1" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{
-			Added: []string{ibcfeetypes.ModuleName},
+			Deleted: []string{ibcfeetypes.ModuleName},
+			Added:   []string{ibcfeetypes.ModuleName},
 		}
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -230,7 +230,7 @@ func New(
 		authtypes.StoreKey, banktypes.StoreKey, stakingtypes.StoreKey,
 		minttypes.StoreKey, distrtypes.StoreKey, slashingtypes.StoreKey,
 		govtypes.StoreKey, paramstypes.StoreKey, ibchost.StoreKey, icahosttypes.StoreKey, upgradetypes.StoreKey, feegrant.StoreKey,
-		evidencetypes.StoreKey, ibctransfertypes.StoreKey, ibcfeetypes.StoreKey, capabilitytypes.StoreKey, authzkeeper.StoreKey,
+		evidencetypes.StoreKey, ibctransfertypes.StoreKey, capabilitytypes.StoreKey, authzkeeper.StoreKey,
 		beamtypes.StoreKey, airdroptypes.StoreKey, dfracttypes.StoreKey,
 	)
 	tkeys := sdk.NewTransientStoreKeys(paramstypes.TStoreKey)
@@ -712,14 +712,10 @@ func (app *App) registerUpgradeHandlers() {
 
 	if upgradeInfo.Name == "v1.3.2" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		// NOT FINALIZED UPGRADE - FOR LATER
+		// TODO: add the storekey to store init line 229
 		storeUpgrades := storetypes.StoreUpgrades{
 			Added: []string{ibcfeetypes.ModuleName},
 		}
-		app.SetStoreLoader(func(ms sdk.CommitMultiStore) error {
-			if err := ms.SetInitialVersion(upgradeInfo.Height); err != nil {
-				panic(err)
-			}
-			return ms.LoadLatestVersionAndUpgrade(&storeUpgrades)
-		})
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}
 }

--- a/app/app.go
+++ b/app/app.go
@@ -656,6 +656,9 @@ func (app *App) registerUpgradeHandlers() {
 	})
 
 	app.UpgradeKeeper.SetUpgradeHandler("v1.3.1", func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		// Set the DFract module consensus version so InitGenesis is not run
+		fromVM[ibcfeetypes.ModuleName] = app.mm.Modules[ibcfeetypes.ModuleName].ConsensusVersion()
+
 		// Apply the new dfract params map
 		app.DFractKeeper.SetParams(ctx, dfracttypes.DefaultParams())
 		app.Logger().Info("v1.3.1 upgrade applied")
@@ -700,11 +703,6 @@ func (app *App) registerUpgradeHandlers() {
 
 	if upgradeInfo.Name == "v1.3.1" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{
-			Deleted: []string{ibcfeetypes.ModuleName},
-		}
-		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
-
-		storeUpgrades = storetypes.StoreUpgrades{
 			Added: []string{ibcfeetypes.ModuleName},
 		}
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))

--- a/app/app.go
+++ b/app/app.go
@@ -657,8 +657,8 @@ func (app *App) registerUpgradeHandlers() {
 
 	app.UpgradeKeeper.SetUpgradeHandler("v1.3.1", func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 		// Set the FeeIBC module consensus version so InitGenesis is not run
-		fromVM[ibcfeetypes.ModuleName] = app.mm.Modules[dfracttypes.ModuleName].ConsensusVersion()
-		
+		fromVM[ibcfeetypes.ModuleName] = 1
+
 		// Apply the new dfract params map
 		app.DFractKeeper.SetParams(ctx, dfracttypes.DefaultParams())
 		app.Logger().Info("v1.3.1 upgrade applied")

--- a/app/app.go
+++ b/app/app.go
@@ -656,12 +656,16 @@ func (app *App) registerUpgradeHandlers() {
 	})
 
 	app.UpgradeKeeper.SetUpgradeHandler("v1.3.1", func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		// Set the IBCFee module consensus version so InitGenesis is not run
-		fromVM[ibcfeetypes.ModuleName] = app.mm.Modules[ibcfeetypes.ModuleName].ConsensusVersion()
-
 		// Apply the new dfract params map
 		app.DFractKeeper.SetParams(ctx, dfracttypes.DefaultParams())
 		app.Logger().Info("v1.3.1 upgrade applied")
+		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
+	})
+
+	app.UpgradeKeeper.SetUpgradeHandler("v1.3.2", func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		// Set the IBCFee module consensus version so InitGenesis is not run
+		fromVM[ibcfeetypes.ModuleName] = app.mm.Modules[ibcfeetypes.ModuleName].ConsensusVersion()
+		app.Logger().Info("v1.3.2 upgrade applied")
 		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
 	})
 


### PR DESCRIPTION
## Description

This pull request fixes the pruning and dfract issues introduced in v1.3.0.

- Current pruning issue is due to an badly initialized module (IBCFee required for later DFract version). We unregister it in the  v1.3.1 and add it for registering on a future v1.3.2 upgrade.
- Current DFract issue is due to the allowed denoms param being changed from string to array of strings, not migrated properly. The upgrade correctly apply the default params to the store and fix the DFract module processing logic.

## Testing

This pull request was released on devnet with success and testnet with success. 
We ensured it fixed everything by configuring pruning to "everything", meaning we had the issue in loop.

Once applied, pruning everything worked again.