### PR TITLE
[LUM-752] Migrate port IDs

### DIFF
--- a/x/millions/keeper/keeper_pool.go
+++ b/x/millions/keeper/keeper_pool.go
@@ -662,7 +662,7 @@ func (k Keeper) UnsafeKillPool(ctx sdk.Context, poolID uint64) (types.Pool, erro
 }
 
 // UnsafeUpdatePoolPortIds This method raw update the provided pool port ids.
-// It's heavily unsafe and could break the ICA implementation. It should be used with cautious caution.
+// It's heavily unsafe and could break the ICA implementation. It should only be used by store migrations.
 func (k Keeper) UnsafeUpdatePoolPortIds(ctx sdk.Context, poolID uint64, icaDepositPortId, icaPrizePoolPortId string) (types.Pool, error) {
 	// Grab our pool instance
 	pool, err := k.GetPool(ctx, poolID)

--- a/x/millions/keeper/keeper_pool.go
+++ b/x/millions/keeper/keeper_pool.go
@@ -661,6 +661,22 @@ func (k Keeper) UnsafeKillPool(ctx sdk.Context, poolID uint64) (types.Pool, erro
 	return pool, nil
 }
 
+// UnsafeUpdatePoolPortIds This method raw update the provided pool port ids.
+// It's heavily unsafe and could break the ICA implementation. It should be used with cautious caution.
+func (k Keeper) UnsafeUpdatePoolPortIds(ctx sdk.Context, poolID uint64, icaDepositPortId, icaPrizePoolPortId string) (types.Pool, error) {
+	// Grab our pool instance
+	pool, err := k.GetPool(ctx, poolID)
+	if err != nil {
+		return types.Pool{}, err
+	}
+
+	// Patch and update our pool entity
+	pool.IcaDepositPortId = icaDepositPortId
+	pool.IcaPrizepoolPortId = icaPrizePoolPortId
+	k.updatePool(ctx, &pool)
+	return pool, nil
+}
+
 func (k Keeper) updatePool(ctx sdk.Context, pool *types.Pool) {
 	pool.UpdatedAt = ctx.BlockTime()
 	pool.UpdatedAtHeight = ctx.BlockHeight()

--- a/x/millions/migrations/migrator.go
+++ b/x/millions/migrations/migrator.go
@@ -2,6 +2,7 @@ package migrations
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	millionskeeper "github.com/lum-network/chain/x/millions/keeper"
 	v150 "github.com/lum-network/chain/x/millions/migrations/v150"
 )

--- a/x/millions/migrations/migrator.go
+++ b/x/millions/migrations/migrator.go
@@ -1,0 +1,20 @@
+package migrations
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	millionskeeper "github.com/lum-network/chain/x/millions/keeper"
+	v150 "github.com/lum-network/chain/x/millions/migrations/v150"
+)
+
+type Migrator struct {
+	keeper millionskeeper.Keeper
+}
+
+func NewMigrator(keeper millionskeeper.Keeper) Migrator {
+	return Migrator{keeper: keeper}
+}
+
+// Migrate1To2 migrates from version 1 to 2
+func (m Migrator) Migrate1To2(ctx sdk.Context) error {
+	return v150.MigratePoolPortIdsToPortOwnerName(ctx, m.keeper)
+}

--- a/x/millions/migrations/v150/store.go
+++ b/x/millions/migrations/v150/store.go
@@ -1,0 +1,34 @@
+package v150
+
+import (
+	"fmt"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	icatypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/types"
+	millionskeeper "github.com/lum-network/chain/x/millions/keeper"
+	millionstypes "github.com/lum-network/chain/x/millions/types"
+	"strings"
+)
+
+func MigratePoolPortIdsToPortOwnerName(ctx sdk.Context, k millionskeeper.Keeper) error {
+	k.IteratePools(ctx, func(pool millionstypes.Pool) bool {
+		// Migrate the deposit port id only if required
+		var updatedDepositPortId = pool.GetIcaDepositPortId()
+		if strings.HasPrefix(pool.GetIcaDepositPortId(), icatypes.ControllerPortPrefix) {
+			updatedDepositPortId = strings.TrimPrefix(pool.GetIcaDepositPortId(), icatypes.ControllerPortPrefix)
+		}
+
+		// Migrate the prizepool port id only if required
+		var updatedPrizePoolPortId = pool.GetIcaPrizepoolPortId()
+		if strings.HasPrefix(pool.GetIcaPrizepoolPortId(), icatypes.ControllerPortPrefix) {
+			updatedPrizePoolPortId = strings.TrimPrefix(pool.GetIcaPrizepoolPortId(), icatypes.ControllerPortPrefix)
+		}
+
+		// Patch our entity
+		if _, err := k.UnsafeUpdatePoolPortIds(ctx, pool.GetPoolId(), updatedDepositPortId, updatedPrizePoolPortId); err != nil {
+			panic(err)
+		}
+		ctx.Logger().Info(fmt.Sprintf("Migrated pool %d port ids | old %s / %s | new %s / %s", pool.GetPoolId(), pool.GetIcaDepositPortId(), pool.GetIcaPrizepoolPortId(), updatedDepositPortId, updatedPrizePoolPortId))
+		return false
+	})
+	return nil
+}

--- a/x/millions/migrations/v150/store.go
+++ b/x/millions/migrations/v150/store.go
@@ -2,11 +2,13 @@ package v150
 
 import (
 	"fmt"
+	"strings"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	icatypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/types"
+
 	millionskeeper "github.com/lum-network/chain/x/millions/keeper"
 	millionstypes "github.com/lum-network/chain/x/millions/types"
-	"strings"
 )
 
 func MigratePoolPortIdsToPortOwnerName(ctx sdk.Context, k millionskeeper.Keeper) error {

--- a/x/millions/migrations/v150/store_test.go
+++ b/x/millions/migrations/v150/store_test.go
@@ -1,11 +1,13 @@
 package v150_test
 
 import (
-	icatypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/types"
-	apptesting "github.com/lum-network/chain/app/testing"
 	"strings"
 	"testing"
 	"time"
+
+	icatypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/types"
+
+	apptesting "github.com/lum-network/chain/app/testing"
 
 	"github.com/stretchr/testify/suite"
 

--- a/x/millions/migrations/v150/store_test.go
+++ b/x/millions/migrations/v150/store_test.go
@@ -1,0 +1,183 @@
+package v150_test
+
+import (
+	icatypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/types"
+	apptesting "github.com/lum-network/chain/app/testing"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	apptypes "github.com/lum-network/chain/app"
+	v150 "github.com/lum-network/chain/x/millions/migrations/v150"
+	millionstypes "github.com/lum-network/chain/x/millions/types"
+)
+
+type StoreMigrationTestSuite struct {
+	suite.Suite
+
+	ctx         sdk.Context
+	app         *apptypes.App
+	addrs       []sdk.AccAddress
+	moduleAddrs []sdk.AccAddress
+	valAddrs    []sdk.ValAddress
+}
+
+// newValidPool fills up missing params to the pool to make it valid in order to ease testing
+func newValidPool(suite *StoreMigrationTestSuite, pool millionstypes.Pool) *millionstypes.Pool {
+	params := suite.app.MillionsKeeper.GetParams(suite.ctx)
+
+	if pool.Denom == "" {
+		pool.Denom = suite.app.StakingKeeper.BondDenom(suite.ctx)
+	}
+	if pool.NativeDenom == "" {
+		pool.NativeDenom = suite.app.StakingKeeper.BondDenom(suite.ctx)
+	}
+	if pool.ChainId == "" {
+		pool.ChainId = "lum-network-devnet"
+	}
+	if pool.Validators == nil {
+		for _, addr := range suite.valAddrs {
+			pool.Validators = append(pool.Validators, millionstypes.PoolValidator{
+				OperatorAddress: addr.String(),
+				BondedAmount:    sdk.ZeroInt(),
+				IsEnabled:       true,
+			})
+		}
+	}
+	if pool.Bech32PrefixAccAddr == "" {
+		pool.Bech32PrefixAccAddr = sdk.GetConfig().GetBech32AccountAddrPrefix()
+	}
+	if pool.Bech32PrefixValAddr == "" {
+		pool.Bech32PrefixValAddr = sdk.GetConfig().GetBech32ValidatorAddrPrefix()
+	}
+	if pool.MinDepositAmount.IsNil() {
+		pool.MinDepositAmount = params.MinDepositAmount
+	}
+	if err := pool.DrawSchedule.ValidateBasic(params); err != nil {
+		pool.DrawSchedule = millionstypes.DrawSchedule{DrawDelta: 1 * time.Hour, InitialDrawAt: time.Now().UTC()}
+	}
+	if err := pool.PrizeStrategy.Validate(params); err != nil {
+		pool.PrizeStrategy = millionstypes.PrizeStrategy{PrizeBatches: []millionstypes.PrizeBatch{{PoolPercent: 100, Quantity: 1, DrawProbability: sdk.NewDec(1)}}}
+	}
+	if pool.LocalAddress == "" {
+		pool.LocalAddress = suite.moduleAddrs[0].String()
+	}
+	if pool.IcaDepositAddress == "" {
+		pool.IcaDepositAddress = suite.moduleAddrs[1].String()
+	}
+	if pool.IcaPrizepoolAddress == "" {
+		pool.IcaPrizepoolAddress = suite.moduleAddrs[2].String()
+	}
+	if pool.NextDrawId == millionstypes.UnknownID {
+		pool.NextDrawId = millionstypes.UnknownID + 1
+	}
+	if pool.TvlAmount.IsNil() {
+		pool.TvlAmount = sdk.ZeroInt()
+	}
+	if pool.SponsorshipAmount.IsNil() {
+		pool.SponsorshipAmount = sdk.ZeroInt()
+	}
+	if pool.AvailablePrizePool.IsNil() {
+		pool.AvailablePrizePool = sdk.NewCoin(pool.Denom, sdk.ZeroInt())
+	}
+	if pool.State == millionstypes.PoolState_Unspecified {
+		pool.State = millionstypes.PoolState_Ready
+	}
+	if pool.CreatedAt.IsZero() {
+		pool.CreatedAt = suite.ctx.BlockTime()
+	}
+	if pool.UpdatedAt.IsZero() {
+		pool.UpdatedAt = suite.ctx.BlockTime()
+	}
+	if pool.IcaDepositPortId == "" {
+		pool.IcaDepositPortId = icatypes.ControllerPortPrefix + string(millionstypes.NewPoolName(pool.GetPoolId(), millionstypes.ICATypeDeposit))
+	}
+	if pool.IcaPrizepoolPortId == "" {
+		pool.IcaPrizepoolPortId = icatypes.ControllerPortPrefix + string(millionstypes.NewPoolName(pool.GetPoolId(), millionstypes.ICATypePrizePool))
+	}
+	return &pool
+}
+
+func (suite *StoreMigrationTestSuite) SetupTest() {
+	app := apptypes.SetupForTesting(false)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+
+	// Setup the default application
+	suite.app = app
+	suite.ctx = ctx.WithChainID("lum-network-devnet").WithBlockTime(time.Now().UTC())
+
+	// Setup test account addresses
+	suite.addrs = apptesting.AddTestAddrsWithDenom(app, ctx, 6, sdk.NewInt(10_000_000_000), app.StakingKeeper.BondDenom(ctx))
+	for i := 0; i < 6; i++ {
+		poolAddress := millionstypes.NewPoolAddress(uint64(i+1), "unused-in-test")
+		apptesting.AddTestModuleAccount(app, ctx, poolAddress)
+		suite.moduleAddrs = append(suite.moduleAddrs, poolAddress)
+	}
+
+	// Setup vals for pools
+	vals := app.StakingKeeper.GetAllValidators(ctx)
+	suite.valAddrs = []sdk.ValAddress{}
+	for _, v := range vals {
+		addr, err := sdk.ValAddressFromBech32(v.OperatorAddress)
+		suite.Require().NoError(err)
+		suite.valAddrs = append(suite.valAddrs, addr)
+	}
+
+	// Setup test params
+	suite.app.MillionsKeeper.SetParams(ctx, millionstypes.Params{
+		MinDepositAmount:        sdk.NewInt(millionstypes.MinAcceptableDepositAmount),
+		MaxPrizeStrategyBatches: 1_000,
+		MaxPrizeBatchQuantity:   1_000_000,
+		MinDrawScheduleDelta:    1 * time.Hour,
+		MaxDrawScheduleDelta:    366 * 24 * time.Hour,
+		PrizeExpirationDelta:    30 * 24 * time.Hour,
+		FeesStakers:             sdk.ZeroDec(),
+		MinDepositDrawDelta:     millionstypes.MinAcceptableDepositDrawDelta,
+	})
+}
+
+func (suite *StoreMigrationTestSuite) TestUpdatePortIds() {
+	poolID := suite.app.MillionsKeeper.GetNextPoolIDAndIncrement(suite.ctx)
+	suite.app.MillionsKeeper.AddPool(suite.ctx, newValidPool(suite, millionstypes.Pool{PoolId: poolID}))
+
+	// Grab our pool entity
+	pool, err := suite.app.MillionsKeeper.GetPool(suite.ctx, poolID)
+	suite.Require().NoError(err)
+
+	// Save old value for further testing
+	oldDepositPortId := pool.GetIcaDepositPortId()
+	oldPrizepoolPortId := pool.GetIcaPrizepoolPortId()
+
+	// Ensure our pool has the old setup
+	suite.Require().True(strings.HasPrefix(oldDepositPortId, icatypes.ControllerPortPrefix))
+	suite.Require().True(strings.HasPrefix(oldPrizepoolPortId, icatypes.ControllerPortPrefix))
+
+	// Run the migration operation
+	err = v150.MigratePoolPortIdsToPortOwnerName(suite.ctx, *suite.app.MillionsKeeper)
+	suite.Require().NoError(err)
+
+	// Grab again our pool
+	pool, err = suite.app.MillionsKeeper.GetPool(suite.ctx, poolID)
+	suite.Require().NoError(err)
+
+	// Ensure our pool has the new setup
+	suite.Require().False(strings.HasPrefix(pool.GetIcaDepositPortId(), icatypes.ControllerPortPrefix))
+	suite.Require().False(strings.HasPrefix(pool.GetIcaPrizepoolPortId(), icatypes.ControllerPortPrefix))
+
+	// Make sure it matches the new format
+	newFormatPortNameDeposit := string(millionstypes.NewPoolName(pool.GetPoolId(), millionstypes.ICATypeDeposit))
+	newFormatPortNamePrizepool := string(millionstypes.NewPoolName(pool.GetPoolId(), millionstypes.ICATypePrizePool))
+	suite.Require().Equal(newFormatPortNameDeposit, pool.GetIcaDepositPortId())
+	suite.Require().Equal(newFormatPortNamePrizepool, pool.GetIcaPrizepoolPortId())
+	suite.Require().Equal(oldDepositPortId, pool.GetIcaDepositPortIdWithPrefix())
+	suite.Require().Equal(oldPrizepoolPortId, pool.GetIcaPrizepoolPortIdWithPrefix())
+}
+
+func TestKeeperSuite(t *testing.T) {
+	suite.Run(t, new(StoreMigrationTestSuite))
+}

--- a/x/millions/module.go
+++ b/x/millions/module.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/lum-network/chain/x/millions/migrations"
 
 	"github.com/gorilla/mux"

--- a/x/millions/module.go
+++ b/x/millions/module.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/lum-network/chain/x/millions/migrations"
 
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -121,6 +122,13 @@ func (a AppModule) QuerierRoute() string {
 func (a AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServerImpl(a.keeper))
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(a.keeper))
+
+	// Register the migrations
+	migrator := migrations.NewMigrator(a.keeper)
+	err := cfg.RegisterMigration(types.ModuleName, 1, migrator.Migrate1To2)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func (a AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {

--- a/x/millions/types/keys.go
+++ b/x/millions/types/keys.go
@@ -14,7 +14,7 @@ import (
 const (
 	ModuleName = "millions"
 
-	ModuleVersion = 1
+	ModuleVersion = 2
 
 	StoreKey = ModuleName
 


### PR DESCRIPTION
### Introduction

On the v1.5.0 upgrade, we bump IBC to v7 and thus it's required to change the way we store the port IDs.
For the newly created pools, it's already fixed. But older ones must be patched.

This PR introduces this change.

### Testing
Unit testing were added.
Manual testing is expected on dedicated test network