### PR TITLE
[LUM-767] Fix to use correct port owner / name

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -824,7 +824,7 @@ func (app *App) registerUpgradeHandlers() {
 		}
 
 		// Run migrations to ensure we patch our IBC channels names
-		vm, err := app.mm.RunMigrations(ctx, app.configurator, fromVM)
+		vm, _ := app.mm.RunMigrations(ctx, app.configurator, fromVM)
 
 		// Change the Millions Pool prize strategy
 		// We check if we are able to find the pool with ID 2, but we don't error out in the other case, to allow running on testnet as well

--- a/x/millions/keeper/keeper_pool.go
+++ b/x/millions/keeper/keeper_pool.go
@@ -2,9 +2,10 @@ package keeper
 
 import (
 	"fmt"
+	"strconv"
+
 	icacontrollerkeeper "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/controller/keeper"
 	icacontrollertypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/controller/types"
-	"strconv"
 
 	"github.com/cosmos/gogoproto/proto"
 	gogotypes "github.com/cosmos/gogoproto/types"


### PR DESCRIPTION
### Introduction

Following major v1.5.0 upgrade (featuring SDK 0.47 and IBC V7) we introduced an issue.

Previously, our ICA channels name were in the following format `icacontroller-pool.2.deposit` and `icacontroller-pool.2.prizepool`.
Due to IBC V7, we had to migrate back to a format without the `icacontroller-` prefix. We had to reflect this change over the whole codebase. 
A leftover piece of code wasn't handling this change correctly.

This proposal fix it. It also patches the prize distribution to reflect Lum Network willingness to improve the odds for the Millions depositors.

### Testing

PR is going to be released over official Lum Network testnet which also has the issue.