### PR TITLE
[LUM-856] Restoring ICA should restore blocked entities

### DIFF
--- a/x/millions/keeper/keeper_epoch_test.go
+++ b/x/millions/keeper/keeper_epoch_test.go
@@ -255,9 +255,12 @@ func (suite *KeeperTestSuite) TestEpoch_AddEpochUnbonding() {
 	suite.Require().Equal([]uint64{1, 2}, epochUnbondingPool.WithdrawalIds)
 	suite.Require().Equal(uint64(2), epochUnbondingPool.WithdrawalIdsCount)
 
-	// Same withdrawalID to the epoch unbonding should faild
+	// Same withdrawalID to the epoch unbonding should do nothing
 	err = app.MillionsKeeper.AddEpochUnbonding(ctx, withdrawals[0], false)
-	suite.Require().ErrorIs(millionstypes.ErrEntityOverride, err)
+	suite.Require().NoError(err)
+	epochUnbondingPoolAfter, err := app.MillionsKeeper.GetEpochPoolUnbonding(ctx, epochTracker.EpochNumber+frequency, 1)
+	suite.Require().NoError(err)
+	suite.Require().Equal(epochUnbondingPool.WithdrawalIds, epochUnbondingPoolAfter.WithdrawalIds)
 
 	// Trigger new deposits for new pool
 	for i := 0; i < 3; i++ {

--- a/x/millions/keeper/keeper_withdrawal.go
+++ b/x/millions/keeper/keeper_withdrawal.go
@@ -82,13 +82,12 @@ func (k Keeper) OnUndelegateWithdrawalsOnRemoteZoneCompleted(ctx sdk.Context, po
 			if err := k.AddEpochUnbonding(ctx, withdrawal, true); err != nil {
 				return err
 			}
-			continue
+		} else {
+			// Set the unbondingEndsAt and add withdrawal to matured queue
+			withdrawal.UnbondingEndsAt = unbondingEndsAt
+			k.UpdateWithdrawalStatus(ctx, withdrawal.PoolId, withdrawal.WithdrawalId, types.WithdrawalState_IcaUnbonding, unbondingEndsAt, false)
+			k.addWithdrawalToMaturedQueue(ctx, withdrawal)
 		}
-
-		// Set the unbondingEndsAt and add withdrawal to matured queue
-		withdrawal.UnbondingEndsAt = unbondingEndsAt
-		k.UpdateWithdrawalStatus(ctx, withdrawal.PoolId, withdrawal.WithdrawalId, types.WithdrawalState_IcaUnbonding, unbondingEndsAt, false)
-		k.addWithdrawalToMaturedQueue(ctx, withdrawal)
 	}
 
 	if isError {

--- a/x/millions/keeper/msg_server_withdrawal.go
+++ b/x/millions/keeper/msg_server_withdrawal.go
@@ -130,6 +130,13 @@ func (k msgServer) WithdrawDepositRetry(goCtx context.Context, msg *types.MsgWit
 		if err := k.TransferWithdrawalToRecipient(ctx, withdrawal.PoolId, withdrawal.WithdrawalId); err != nil {
 			return nil, err
 		}
+	} else if withdrawal.ErrorState == types.WithdrawalState_IcaUndelegate {
+		// Only possible following a restore account which put entities in this error state
+		// otherwise the retry is automatically triggered by the ICA callback
+		err := k.AddEpochUnbonding(ctx, withdrawal, true)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		return nil, errorsmod.Wrapf(
 			types.ErrInvalidWithdrawalState,


### PR DESCRIPTION
**Restoring an ICA account (following a channel freeze) must restore all the blocked entities:**
- Deposits (ICA delegate)
- Withdrawals (ICA undelegate)
- Draws (ICA withdraw rewards and ICQ query balance for ICA prize account)

**Tests:**
- Must be done in pre-production by forcing a channel freeze while deposit and withdraw operations are getting triggered